### PR TITLE
Add google analytics to track plugin usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,23 @@ register - A list of information designed to be an accurate and up-to-date sourc
 territory - An administrative or geographical entity that isn't recognised as a country by the UK.
 
 territory register - A list of British English-language names and descriptive terms for political, administrative and geographical entities that aren’t recognised as countries by the UK.
+
+## Tracking
+
+We use Google Analytics software to collect information about how your users interact with this component. We do this to help make sure the component is meeting the needs of its users and to help us make improvements.
+
+The Google Analytics cookie we set stores information about:
+
+- how many users enter country data using the component the hostname of the service which the component is implemented within
+
+We don’t collect or store you or your users' personal information (for example your name or address) so this information can’t be used to identify who you are.
+
+We don’t allow Google to use or share our analytics data.
+
+We've renamed this cookie to [add cookie name] so it won't clash with any Google Analytics cookies you set yourself to monitor your service.
+
+If you're happy for this cookie to be placed in your service, you'll need to let your users know about this clearly and may need to update your cookie policy. We suggest adding some wording like the below:
+
+One or more of the parts of this service were designed and built by the Government Digital Service (GDS). We may also send Google Analytics cookie data to GDS so that they can monitor and improve those parts of the service.
+
+If you'd prefer not to place this cookie in your service, you can take it out by setting before disableGoogleAnalytics: "true"; in your initialiser.

--- a/examples/index.html
+++ b/examples/index.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Openregister Location Picker</title>
     <link rel="stylesheet" href="../dist/location-picker.min.css" />
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-90200549-5', 'auto');
+      //ga('send', 'pageview');
+    </script>
     <style>
       html {
         color: #111;
@@ -347,7 +356,8 @@
         ],
         defaultValue: '',
         selectElement: document.getElementById('default'),
-        url: '../dist/location-picker-graph.json'
+        url: '../dist/location-picker-graph.json',
+        disableGoogleAnalytics: true
       })
     </script>
   </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,7 +12,7 @@
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-90200549-5', 'auto');
-      //ga('send', 'pageview');
+      ga('send', 'pageview');
     </script>
     <style>
       html {

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Openregister Location Picker</title>
+    <title>GOV.UK country and territory autocomplete</title>
     <link rel="stylesheet" href="../dist/location-picker.min.css" />
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -59,7 +59,7 @@
   </head>
   <body>
     <main>
-      <h1>Openregister Location Picker</h1>
+      <h1>GOV.UK country and territory autocomplete</h1>
 
       <h2>Basic example</h2>
       <p>This illustrates basic usage.</p>
@@ -357,7 +357,7 @@
         defaultValue: '',
         selectElement: document.getElementById('default'),
         url: '../dist/location-picker-graph.json',
-        disableGoogleAnalytics: true
+        allowAdoptionTracking: true
       })
     </script>
   </body>

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,16 @@ function suggestionTemplate (result) {
   return result && '<strong>' + result.name + '</strong>' + path
 }
 
+function initGoogleAnalytics () {
+  ga('create', {
+    trackingId: 'UA-90200549-4',
+    cookieDomain: '_gaCookieLocationPickerComponent',
+    name: 'openregisterLocationPicker',
+  });
+
+  ga("set", "anonymizeIp", true);
+}
+
 function openregisterLocationPicker (opts) {
   // Set defaults.
   opts.fallback = opts.fallback || ((query, syncResults) => {
@@ -58,6 +68,10 @@ function openregisterLocationPicker (opts) {
   }
 
   enhanceSelectElement(opts)
+
+  if (!opts.disableGoogleAnalytics) {
+    initGoogleAnalytics()
+  }
 }
 
 module.exports = openregisterLocationPicker

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ function suggestionTemplate (result) {
   return result && '<strong>' + result.name + '</strong>' + path
 }
 
-function initGoogleAnalytics () {
+// If enabled, this function provides the GOV.UK Registers team with information about your hostname in order to track the component's usage
+function initGoogleAnalyticsTracking () {
   ga('create', {
     trackingId: 'UA-90200549-4',
     cookieDomain: '_gaCookieLocationPickerComponent',
@@ -69,8 +70,8 @@ function openregisterLocationPicker (opts) {
 
   enhanceSelectElement(opts)
 
-  if (!opts.disableGoogleAnalytics) {
-    initGoogleAnalytics()
+  if (opts.allowAdoptionTracking) {
+    initGoogleAnalyticsTracking()
   }
 }
 


### PR DESCRIPTION
This change is to enable usage tracking of this component.

There is a `disable` option for services if they don't want to allow the tracking.

The readme gives this change some context