### PR TITLE
Updates country Burma to Myanmar (Burma)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- [Pull request #56: Updates country Burma to Myanmar (Burma)](https://github.com/alphagov/govuk-country-and-territory-autocomplete/pull/56)
+
 ## 0.5.2 - 2019-03-18
 
 - Pull in latest register data.

--- a/dist/location-autocomplete-canonical-list.json
+++ b/dist/location-autocomplete-canonical-list.json
@@ -164,7 +164,7 @@
     "country:BF"
   ],
   [
-    "Burma",
+    "Myanmar (Burma)",
     "country:MM"
   ],
   [

--- a/dist/location-autocomplete-graph.json
+++ b/dist/location-autocomplete-graph.json
@@ -1884,7 +1884,7 @@
     },
     "names": {
       "cy": false,
-      "en-GB": "Burma"
+      "en-GB": "Myanmar (Burma)"
     }
   },
   "country:MN": {
@@ -12839,23 +12839,6 @@
       "en-GB": "Myanma"
     }
   },
-  "nym:Myanmar": {
-    "edges": {
-      "from": [
-        "country:MM"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": false,
-      "stable-name": false
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "Myanmar"
-    }
-  },
   "nym:México": {
     "edges": {
       "from": [
@@ -22578,23 +22561,6 @@
     "names": {
       "cy": false,
       "en-GB": "Union of Soviet Socialist Republics"
-    }
-  },
-  "nym:Union of burma": {
-    "edges": {
-      "from": [
-        "country:MM"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": false,
-      "stable-name": false
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "Union of burma"
     }
   },
   "nym:Union of the Comoros": {

--- a/examples/index.html
+++ b/examples/index.html
@@ -99,7 +99,6 @@
           <option value="country:BN">Brunei</option>
           <option value="country:BG">Bulgaria</option>
           <option value="country:BF">Burkina Faso</option>
-          <option value="country:MM">Burma</option>
           <option value="country:BI">Burundi</option>
           <option value="country:KH">Cambodia</option>
           <option value="country:CM">Cameroon</option>
@@ -226,6 +225,7 @@
           <option value="territory:MS">Montserrat</option>
           <option value="country:MA">Morocco</option>
           <option value="country:MZ">Mozambique</option>
+          <option value="country:MM">Myanmar (Burma)</option>
           <option value="country:NA">Namibia</option>
           <option value="country:NR">Nauru</option>
           <option value="territory:UM-76">Navassa Island</option>


### PR DESCRIPTION
This is consistent with the GOV.UK Country Register:

https://country.register.gov.uk/records/MM/entries