### PR TITLE
Release version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.1 - 2019-10-31
+
 ### Fixes
 
 - [Pull request #66: Fix preselected values causing undefined errors](https://github.com/alphagov/govuk-country-and-territory-autocomplete/pull/66)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-country-and-territory-autocomplete",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/location-autocomplete.min.js",
   "description": "An autocomplete widget that uses data from the GOV.UK Registers.",
   "repository": "git@github.com:alphagov/govuk-country-and-territory-autocomplete.git",


### PR DESCRIPTION
### Fixes

- [Pull request #66: Fix preselected values causing undefined errors](https://github.com/alphagov/govuk-country-and-territory-autocomplete/pull/66)