### PR TITLE
Fix npm install example for location autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can also install the location autocomplete using `npm`:
 
 ```bash
 $ npm install govuk-country-and-territory-autocomplete
-$ ls node_modules/openregister-location-autocomplete/dist/
+$ ls node_modules/govuk-country-and-territory-autocomplete/dist/
 location-autocomplete-canonical-list.json
 location-autocomplete-graph.json
 location-autocomplete.min.css


### PR DESCRIPTION
Fixes [#38](https://github.com/alphagov/govuk-country-and-territory-autocomplete/issues/38).

This PR updates the repo README with the correct info about where files are sent after users run npm to install the location autocomplete.